### PR TITLE
clear timers

### DIFF
--- a/src/poolWorker.ts
+++ b/src/poolWorker.ts
@@ -25,7 +25,7 @@ export class PoolWorker extends Worker {
       const onMessage = (res: any) => {
         this.removeListener('error', onError);
         if (this._taskPromiseWithTimer) {
-          this._taskPromiseWithTimer.cleanTimer();
+          this._taskPromiseWithTimer.clearTimer();
         }
         this.setReadyToWork();
         resolve(res);
@@ -34,7 +34,7 @@ export class PoolWorker extends Worker {
       const onError = (err: any) => {
         this.removeListener('message', onMessage);
         if (this._taskPromiseWithTimer) {
-          this._taskPromiseWithTimer.cleanTimer();
+          this._taskPromiseWithTimer.clearTimer();
         }
         reject(err);
       };
@@ -59,7 +59,7 @@ export class PoolWorker extends Worker {
       });
     });
     if (this._taskPromiseWithTimer) {
-      this._taskPromiseWithTimer.cleanTimer();
+      this._taskPromiseWithTimer.clearTimer();
     }
     return super.terminate();
   }

--- a/src/poolWorker.ts
+++ b/src/poolWorker.ts
@@ -4,6 +4,7 @@ import { TaskConfig } from './taskContainer';
 
 export class PoolWorker extends Worker {
   private _ready = false;
+  private _taskPromiseWithTimer: PromiseWithTimer | undefined = undefined;
 
   constructor(...args: ConstructorParameters<typeof Worker>) {
     super(...args);
@@ -23,12 +24,18 @@ export class PoolWorker extends Worker {
     const taskPromise = new Promise((resolve, reject) => {
       const onMessage = (res: any) => {
         this.removeListener('error', onError);
+        if (this._taskPromiseWithTimer) {
+          this._taskPromiseWithTimer.cleanTimer();
+        }
         this.setReadyToWork();
         resolve(res);
       };
 
       const onError = (err: any) => {
         this.removeListener('message', onMessage);
+        if (this._taskPromiseWithTimer) {
+          this._taskPromiseWithTimer.cleanTimer();
+        }
         reject(err);
       };
 
@@ -36,8 +43,8 @@ export class PoolWorker extends Worker {
       this.once('error', onError);
       this.postMessage(param, transferList);
     });
-
-    return new PromiseWithTimer(taskPromise, timeout).startRace();
+    this._taskPromiseWithTimer = new PromiseWithTimer(taskPromise, timeout);
+    return this._taskPromiseWithTimer.startRace();
   }
 
   private setReadyToWork(): void {
@@ -51,7 +58,9 @@ export class PoolWorker extends Worker {
         this.removeAllListeners();
       });
     });
-
+    if (this._taskPromiseWithTimer) {
+      this._taskPromiseWithTimer.cleanTimer();
+    }
     return super.terminate();
   }
 }

--- a/src/promiseWithTimer.ts
+++ b/src/promiseWithTimer.ts
@@ -41,7 +41,7 @@ export class PromiseWithTimer<T = any> {
     return result as T;
   }
 
-  async cleanTimer() {
+  async clearTimer() {
     if (this.timerId) {
       clearTimeout(this.timerId);
     }

--- a/src/promiseWithTimer.ts
+++ b/src/promiseWithTimer.ts
@@ -40,4 +40,10 @@ export class PromiseWithTimer<T = any> {
     clearTimeout(this.timerId);
     return result as T;
   }
+
+  async cleanTimer() {
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
+  }
 }


### PR DESCRIPTION
When running unit tests that involve worker pools I noticed this warning from jest:
```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

Further investigation showed that the timeouts created by `node-worker-threads-pool` are still active and blocking jest from stopping.

This PR is a proposal to fix this. Whenever a task is done (successful or not) then the timeout is cleared. I am not sure how to test this properly though. Locally I was able to get rid of the jest warnings using my modifications.